### PR TITLE
make show on boot settable

### DIFF
--- a/ServerView.sc
+++ b/ServerView.sc
@@ -1,6 +1,6 @@
 ServerView : Singleton {
 	classvar panelTypes, <>widgets, <actions, <>border=true,
-	showOnBoot=true, serverViewShown=false;
+	>showOnBoot=true, serverViewShown=false;
 	var <>view, <window, widgetLayout, server, <>widgets, containers;
 
 	*initClass {


### PR DESCRIPTION
Hey 
this makes it possible to set a preference for whether or not the serverview should pop up at boot time by adding eg 
```
ServerView.showOnBoot = false
```
to your startupfile.